### PR TITLE
feat(client-lib): Added destroy methods to the authorization client and token helper classes

### DIFF
--- a/packages/client-lib/src/authorization_client.ts
+++ b/packages/client-lib/src/authorization_client.ts
@@ -66,7 +66,7 @@ export class AuthorizationClient implements IAuthorizationClient{
     private _privileges:Privilege[] = [];
 
     constructor(
-        boundedContextName: string, 
+        boundedContextName: string,
         privilegeSetVersion: string,
         authSvcBaseUrl:string, logger:ILogger,
         authRequester: IAuthenticatedHttpRequester, messageConsumer:IMessageConsumer|null = null
@@ -143,6 +143,13 @@ export class AuthorizationClient implements IAuthorizationClient{
             this._messageConsumer.setCallbackFn(this._messageHandler.bind(this));
             await this._messageConsumer.connect();
             await this._messageConsumer.startAndWaitForRebalance();
+        }
+    }
+
+    async destroy():Promise<void>{
+        if(this._messageConsumer){
+            await this._messageConsumer.stop();
+            await this._messageConsumer.destroy(false);
         }
     }
 

--- a/packages/client-lib/src/token_helper.ts
+++ b/packages/client-lib/src/token_helper.ts
@@ -132,6 +132,11 @@ export class TokenHelper implements ITokenHelper {
 
     async destroy(): Promise<void> {
         if(this._updateTimer) clearInterval(this._updateTimer);
+
+        if(this._messageConsumer){
+            await this._messageConsumer.stop();
+            await this._messageConsumer.destroy(false);
+        }
     }
 
     private async _messageHandler(message:IMessage):Promise<void>{


### PR DESCRIPTION
Added destroy methods to the authorization client and token helper classes so their respective message consumers can be destroyed gracefully